### PR TITLE
fix: remove preview links from cms ui

### DIFF
--- a/keystatic.config.tsx
+++ b/keystatic.config.tsx
@@ -4,7 +4,7 @@ import { block, mark, wrapper } from "@keystatic/core/content-components";
 import { DownloadIcon, ImageIcon, LinkIcon, ListIcon } from "lucide-react";
 
 import { Logo } from "@/components/logo";
-import { createAssetPaths, createPreviewUrl } from "@/config/content.config";
+import { createAssetPaths } from "@/config/content.config";
 import { env } from "@/config/env.config";
 
 function createComponents(
@@ -120,7 +120,6 @@ export default config({
 			path: "./content/pages/**",
 			slugField: "title",
 			format: { contentField: "content" },
-			previewUrl: createPreviewUrl("/{slug}"),
 			entryLayout: "content",
 			columns: ["title"],
 			schema: {

--- a/src/config/content.config.ts
+++ b/src/config/content.config.ts
@@ -1,16 +1,6 @@
-import { env } from "@/config/env.config";
-
 export function createAssetPaths(segment: `/${string}/`) {
 	return {
 		directory: `./public/assets${segment}`,
 		publicPath: `/assets${segment}`,
 	};
-}
-
-export function createPreviewUrl(previewUrl: string) {
-	if (env.PUBLIC_KEYSTATIC_MODE === "github") {
-		return `/api/preview/start?branch={branch}&to=${previewUrl}`;
-	}
-
-	return previewUrl;
 }


### PR DESCRIPTION
remove preview link button from cms. currently, previews are only supported with next.js but not with astro.

closes #4